### PR TITLE
Add Keploy Mocking and Test Coverage Prompts to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,3 +495,15 @@ This repository contains prompt chains for the following domains:
   ```text
   "Set up a CI/CD pipeline to automatically run Keploy tests as part of the deployment process. Include configuration for GitHub Actions or Jenkins to run tests whenever new code is pushed to the repository."
   ```
+
+* **Keploy Mocking and Dependency Management Prompt**
+
+  ```text
+  "Configure Keploy to mock external dependencies such as databases and third-party APIs during test replay. Include setup instructions to isolate tests from production services for accurate results."
+  ```
+
+* **Keploy Test Coverage and Report Integration**
+
+  ```text
+  "Set up Keploy to generate test coverage reports and integrate them into your CI/CD pipeline dashboard. Ensure reports are uploaded to platforms like Codecov or SonarQube for visibility and analysis."
+  ```


### PR DESCRIPTION
**This PR adds two new usage prompts to the README.md to guide developers on enhancing their Keploy integration with mocking capabilities and test coverage reporting. These additions aim to improve the documentation by providing clear, actionable ideas for leveraging Keploy in real-world workflows.**

**Purpose**

- _Help contributors and adopters of Keploy understand best practices for mocking and test isolation_
- _Encourage teams to integrate test coverage reporting for better observability and quality assurance_
- _Serve as ready-to-use prompts for automation, blog ideas, or further community contributions_


**Acknowledgements**

_Grateful to the Keploy team and open-source contributors who promote comprehensive, automated testing through tooling and clear documentation._