### PR TITLE
Prompt: Amazon S3 as a Static Website with CI/CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,11 @@ This repository contains prompt chains for the following domains:
   ```text
   "Please provide the steps for setting up cloud storage using Amazon S3. Include how to create a bucket, set permissions, and manage files programmatically via AWS SDKs. Return the necessary code examples for integration."
   ```
+* **Amazon S3 as a Static Website with CI/CD**
+
+ ```text
+   "Show how to host a static website on Amazon S3 and automate deployment using GitHub Actions. Include IAM policy setup, bucket website configuration, and the workflow YAML for uploading files on push."
+  ```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ This repository contains prompt chains for the following domains:
 * **Amazon S3 as a Static Website with CI/CD**
 
  ```text
-   "Show how to host a static website on Amazon S3 and automate deployment using GitHub Actions. Include IAM policy setup, bucket website configuration, and the workflow YAML for uploading files on push."
+   "Demonstrate how to host a static website on Amazon S3 and automate its deployment with GitHub Actions. Include S3 bucket website configuration, IAM policy setup, and a GitHub Actions workflow that uploads files on every push to the main branch."
   ```
 
 ---


### PR DESCRIPTION
The prompt guides users through setting up a static website on Amazon S3 and automating deployments using GitHub Actions. It covers configuring the S3 bucket for public access, writing a secure IAM policy, and creating a GitHub Actions workflow that pushes website files to S3 on every commit to the main branch. Bonus challenges include adding cache-control headers and handling CloudFront cache invalidation.
The goal is to help learners understand how to deploy static sites on AWS with modern CI/CD practices.