### PR TITLE
Prompt for Scaffold-Django-REST-API for a specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,3 +495,8 @@ This repository contains prompt chains for the following domains:
   ```text
   "Set up a CI/CD pipeline to automatically run Keploy tests as part of the deployment process. Include configuration for GitHub Actions or Jenkins to run tests whenever new code is pushed to the repository."
   ```
+* **Scaffold Django REST API from Specification**  
+  
+  ```text
+  "Given a model name and its fields, generate Django model code, serializer, views (class-based using DRF), and URL configuration to build a complete CRUD API. Also include sample cURL requests and instructions for enabling JWT authentication in settings.py."
+  ```


### PR DESCRIPTION
This PR adds a new prompt under API Development to help developers scaffold full Django REST APIs (models, views, serializers, URLs, JWT setup) from a specification. It saves time and reduces boilerplate when building CRUD APIs.